### PR TITLE
Gate egraph-folding behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ sv-parser = "0.13.3"
 
 [lints.clippy]
 manual_range_contains = "allow"
+
+[features]
+default = []
+# We probably don't want the compiler to apply folding on LUTs.
+# It is too expensive
+# default = ["egraph_fold"]
+egraph_fold = []

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -102,6 +102,7 @@ impl Analysis<lut::LutLang> for LutAnalysis {
             _ => LutAnalysisData::default(),
         }
     }
+    #[cfg(feature = "egraph_fold")]
     fn modify(egraph: &mut egg::EGraph<lut::LutLang, Self>, id: egg::Id) {
         let nodes = egraph[id].nodes.clone();
         for node in nodes {

--- a/src/lut.rs
+++ b/src/lut.rs
@@ -628,6 +628,10 @@ impl<'a> LutExprInfo<'a> {
     pub fn is_reduntant(&self) -> bool {
         let slice = self.expr.as_ref();
 
+        if slice.len() < 2 {
+            return false;
+        }
+
         for i in 0..slice.len() {
             let n = &slice[i];
 
@@ -667,4 +671,11 @@ impl<'a> LutExprInfo<'a> {
     pub fn is_canonical(&self) -> bool {
         !(self.is_reduntant() || self.contains_gates())
     }
+}
+
+/// Simplify expressions by greedily folding LUTs based on invariant programs and constant inputs.
+/// This function should also produce expressions that are not redundant.
+pub fn fold_expr_greedily(expr: RecExpr<LutLang>) -> RecExpr<LutLang> {
+    // TODO(matth2k): Implement greedy expression folding
+    expr
 }

--- a/tests/lutlang/invariance_examples.txt
+++ b/tests/lutlang/invariance_examples.txt
@@ -1,4 +1,4 @@
-// RUN: cargo run --release %s -k 5 2>>/dev/null | FileCheck %s
+// RUN: cargo run --features egraph_fold --release %s -k 5 2>>/dev/null | FileCheck %s
 
 // LUT invariant to f
 (LUT 12 a f)


### PR DESCRIPTION
This PR:
1. gates egraph-folding behind a feature flag called `egraph_fold`
2. Created an empty method for folding expressions greedily (this is the TODO)
3. Adds a new argument `--no-canonicalize`