### PR TITLE
Parse escaped identifiers in verilog

### DIFF
--- a/src/verilog.rs
+++ b/src/verilog.rs
@@ -672,7 +672,7 @@ impl SVModule {
                             ));
                         }
                         _ => {
-                            return Err("Expected a SimpleIdentifier or PrimaryLiteral".to_string());
+                            return Err("Expected a Identifier or PrimaryLiteral".to_string());
                         }
                     }
                 }


### PR DESCRIPTION
Resolves #67

Replaced SimpleIdentifiers in code with Identifiers to be able to support EscapedIdentifiers