### PR TITLE
Fix calculating input size in reports

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -70,8 +70,8 @@ impl SynthReport {
         let input_info = LutExprInfo::new(input);
         let input_size = input_info.get_cse().as_ref().len() as u64;
         let input_contains_gates = input_info.contains_gates();
-        let num_inputs = input_info.get_num_inputs() as u64;
-        let num_outputs = input_info.get_num_outputs() as u64;
+        let num_inputs = input_info.get_num_inputs();
+        let num_outputs = input_info.get_num_outputs();
         let input_circuit_stats = input_info.get_circuit_stats();
         let output_info = LutExprInfo::new(output);
         let output_circuit_stats = output_info.get_circuit_stats();

--- a/src/lut.rs
+++ b/src/lut.rs
@@ -780,20 +780,30 @@ impl<'a> LutExprInfo<'a> {
 
     /// Get the (used) inputs of the expression
     pub fn get_inputs(&self) -> Vec<String> {
-        let root = &self.expr[self.root];
-        root.get_input_set(self.expr)
+        let cse = self.get_cse();
+        let mut vec = vec![];
+        for n in cse.as_ref() {
+            if let LutLang::Var(s) = n {
+                vec.push(s.as_str().to_string());
+            }
+        }
+        vec
     }
 
     /// Get the number of (used) inputs of the expression
-    pub fn get_num_inputs(&self) -> usize {
-        self.get_inputs().len()
+    pub fn get_num_inputs(&self) -> u64 {
+        let cse = self.get_cse();
+        cse.as_ref()
+            .iter()
+            .filter(|n| matches!(n, LutLang::Var(_)))
+            .count() as u64
     }
 
     /// Get the number of outputs of the expression
-    pub fn get_num_outputs(&self) -> usize {
+    pub fn get_num_outputs(&self) -> u64 {
         let root = &self.expr[self.root];
         match root {
-            LutLang::Bus(l) => l.len(),
+            LutLang::Bus(l) => l.len() as u64,
             _ => 1,
         }
     }


### PR DESCRIPTION
The `get_num_inputs()` call used `LutLang::get_input_set()` which is really inefficient. Here we can reuse the subexpression elimination call to do a linear time counting of the input wires.